### PR TITLE
feat: add callbackController and callbackFormService for POST /buyer/…

### DIFF
--- a/src/controllers/form-controller.ts
+++ b/src/controllers/form-controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import logger from "@ondc/automation-logger";
 import { getLoggerMetaData } from "../utils/loggingUtils";
-import { htmlFormService } from "../services/form-service";
+import { htmlFormService, callbackFormService } from "../services/form-service";
 
 export async function htmlFormController(req: Request, res: Response) {
 	try {
@@ -43,5 +43,45 @@ export async function htmlFormController(req: Request, res: Response) {
 			error
 		);
 		res.status(500).send("Internal Server Error");
+	}
+}
+
+export async function callbackController(req: Request, res: Response) {
+	try {
+		const { transaction_id, success, message } = req.body ?? {};
+
+		logger.info("Callback received", getLoggerMetaData(req), {
+			transaction_id,
+			success,
+			message,
+		});
+
+		if (!transaction_id) {
+			res.status(400).json({
+				success: false,
+				message: "Missing required field: transaction_id",
+			});
+			return;
+		}
+
+		await callbackFormService(
+			transaction_id,
+			success,
+			message,
+			getLoggerMetaData(req)
+		);
+
+		res.status(200).json({
+			success: true,
+			message: "Callback received and recorded",
+			transaction_id,
+			timestamp: new Date().toISOString(),
+		});
+	} catch (error: any) {
+		logger.error("Error in callback", getLoggerMetaData(req), error);
+		res.status(500).json({
+			success: false,
+			message: `Error processing callback: ${error.message}`,
+		});
 	}
 }

--- a/src/routes/public-routes.ts
+++ b/src/routes/public-routes.ts
@@ -12,6 +12,7 @@ import { getL1Key, getLoggerMetaData } from "../utils/loggingUtils";
 import { sendLogsToNo } from "../services/No-service";
 import { l1ValidationsStore } from "../models/storage-interface-implementations";
 import { performL1validationsSave } from "../validations/L1-validations";
+import { callbackController } from "../controllers/form-controller";
 
 const router = express();
 // router.use(express.json());
@@ -22,19 +23,9 @@ const commController = new CommunicationController();
 const dbController = new DataController();
 const sessionController = new SessionController();
 
-// -----------------------------------------------------------------------
-// Public callback endpoint — no Beckn validation, no session, no forwarding
 // POST /{base}/buyer/callback
-// -----------------------------------------------------------------------
-router.post("/callback", (req: ApiServiceRequest, res: Response) => {
-	const { success, message } = req.body ?? {};
-	logger.info("Callback endpoint hit", { success, message });
-	res.status(200).json({
-		success: success ?? false,
-		message: message ?? "No message provided",
-		timestamp: new Date().toISOString(),
-	});
-});
+// Body: { transaction_id: string, success: boolean|string, message: string }
+router.post("/callback", callbackController);
 
 router.post(
     "/:action",

--- a/src/services/form-service.ts
+++ b/src/services/form-service.ts
@@ -1,5 +1,6 @@
 import { TransactionCacheService } from "./session-service-rewrite";
 import logger from "@ondc/automation-logger";
+import { RedisService } from "ondc-automation-cache-lib";
 export async function htmlFormService(
 	transactionId: string,
 	subscriberUrl: string,
@@ -45,5 +46,28 @@ export async function htmlFormService(
 		subscriberUrl,
 		submissionId,
 		formId,
+	});
+}
+
+export async function callbackFormService(
+	transaction_id: string,
+	success: boolean | string,
+	message: string,
+	loggerMeta: any
+): Promise<void> {
+	const completionKey = `form_completed:${transaction_id}`;
+	await RedisService.setKey(
+		completionKey,
+		JSON.stringify({
+			completed: true,
+			success: success ?? false,
+			message: message ?? "",
+			timestamp: new Date().toISOString(),
+		}),
+		3600
+	);
+	logger.info("Completion flag set in Redis", loggerMeta, {
+		transaction_id,
+		key: completionKey,
 	});
 }


### PR DESCRIPTION
- form-service.ts: add callbackFormService (writes form_completed:{txn_id} to Redis, TTL 3600)
- form-controller.ts: add callbackController (validates transaction_id, delegates to service)
- public-routes.ts: replace inline callback handler with callbackController 1-liner, remove RedisService import

